### PR TITLE
Enhance health checks with new subcommands and formatting options

### DIFF
--- a/check_pve2.py
+++ b/check_pve2.py
@@ -25,6 +25,8 @@
 # ---------------------------------------------------------------
 #
 # changelog:
+# 2026.05.23. v2.0   - disk wearout is reversed to match proxmox UI and make more sense (0=no wearout, 100=full wearout)
+#                    - fix output and add verbosity for disks_health output (include wearout details when OK)
 # 2024.06.03. v1.25  - PVE8 - Ignore the syslog service based on the deprecation in Debian 12.5
 # 2024.04.01. v1.24  - Add ceph-io subcommand
 # 2022.12.13. v1.23  - Add help
@@ -117,6 +119,9 @@ class CheckPVE:
         check_pve_opt.add_argument('--ignore-disk', dest='ignore_disks', action='append', metavar='DISKNAME',
                                         help='Ignore disks in health check, --ignore-disk disk1 --ignore-disk disk2 ...etc', default=[])
 
+        check_pve_opt.add_argument('--ignore-service', dest='ignore_services', action='append', metavar='SVCNAME',
+                                        help='Ignore services in services health check, --ignore-service corosync --ignore_service xyz ...etc', default=[])
+
         check_pve_opt.add_argument('--disk-name', dest='include_disks', action='append', metavar='DISKNAME',
                                         help='Check disks in health check by disk name, --disk-name disk1 --disk-name disk2 ...etc', default=[])
         
@@ -140,11 +145,8 @@ class CheckPVE:
             
             parser.error(f"--warning and --critical arguments are required for '{self.options.subcommand}' subcommand!")
             
-        if self.check_thresholds_scale("increase") == False:
+        if self.check_thresholds_scale() == False:
             parser.error(f"--warning threshold must be lower then --critical threshold for '{self.options.subcommand}' subcommand!")
-        elif self.check_thresholds_scale("decrease") == False:
-            parser.error(f"--warning threshold must be higher then --critical threshold for '{self.options.subcommand}' subcommand!")
-
 
 
     def main(self):
@@ -188,6 +190,7 @@ class CheckPVE:
     @staticmethod
     def output(state, message):
         prefix = state.name
+
         message = '{} - {}'.format(prefix, message)
 
         print(message)
@@ -237,14 +240,9 @@ class CheckPVE:
         return used_number, total_number, my_unit
 
 
-
-    def check_thresholds_scale(self, scale):
-        if (self.options.subcommand == "cpu" or self.options.subcommand == "memory" or self.options.subcommand == "storage" or self.options.subcommand == "swap") and scale == "increase":
+    def check_thresholds_scale(self):
+        if (self.options.subcommand == "cpu" or self.options.subcommand == "memory" or self.options.subcommand == "storage" or self.options.subcommand == "swap" or self.options.subcommand == "disks_health"):
             return(self.options.threshold_warning < self.options.threshold_critical)
-               
-        elif self.options.subcommand == "disks_health" and scale == "decrease": 
-            return(self.options.threshold_critical < self.options.threshold_warning)
-
 
 
     def check_ceph(self, perfdata, subcommand):
@@ -330,26 +328,23 @@ class CheckPVE:
 
     def check_disks_health(self, request_output, subcommand):
         for disk in request_output:
-            disk_vendor = (disk["vendor"]).strip()
+            disk_serial = disk["serial"]
             disk_model = disk["model"]
             disk_type = disk["type"]
             disk_devpath = disk["devpath"]
             disk_health = disk["health"]
-            disk_wearout = disk["wearout"]
-            
+            disk_wearout = 100 - disk["wearout"] # in API we got 0 for maximum wearout and 100 for none; reverse it to match proxmox UI and to make more sense
+            disk_name_with_details = f"{disk_model} ({disk_type}, SN: {disk_serial}) on {disk_devpath}"
+
             if disk_health != "OK" and disk_health != "PASSED" and disk_health != "UNKNOWN":
-                self.result_list.append(f"WARNING - {disk_vendor} - {disk_model} type: {disk_type} on {disk_devpath} is failed: {disk_health}")
-            elif isinstance(disk_wearout, int) and disk_wearout <= self.options.threshold_warning and disk_wearout >= self.options.threshold_critical:
-                self.result_list.append(f"WARNING - {disk_vendor} - {disk_model} type: {disk_type} on {disk_devpath} has low wearout: {disk_wearout}")
-            elif isinstance(disk_wearout, int) and disk_wearout <= self.options.threshold_critical:
-                self.result_list.append(f"CRITICAL - {disk_vendor} - {disk_model} type: {disk_type} on {disk_devpath} has low wearout: {disk_wearout}")
+                self.result_list.append(f"CRITICAL - {disk_name_with_details} has failed: {disk_health}")
+            elif isinstance(disk_wearout, int) and disk_wearout >= self.options.threshold_critical:
+                self.result_list.append(f"CRITICAL - {disk_name_with_details} has high wearout {disk_wearout}%")
+            elif isinstance(disk_wearout, int) and disk_wearout >= self.options.threshold_warning:
+                self.result_list.append(f"WARNING - {disk_name_with_details} has high wearout {disk_wearout}%")
             else:
-                if not any("WARNING" in x for x in self.result_list) or not any("CRITICAL" in x for x in self.result_list):
-                    self.result_list.append(f"OK - All disks are healthy.")
-
-            if any("WARNING" in x for x in self.result_list):
-                self.result_list = [x for x in self.result_list if re.search("WARNING -", x) if re.search("CRITICAL -", x)]
-
+                self.result_list.append(f"OK - {disk_name_with_details} has low wearout {disk_wearout}%")
+	
         self.result_list = set(self.result_list)
 
 
@@ -392,20 +387,18 @@ class CheckPVE:
             service_unit_state = (element["unit-state"])
             service_state = (element["state"])
             service_active_state = (element["active-state"])
+            service_name_with_details = f"{service_name} in state {service_state} ({service_unit_state}, {service_active_state})"
 
-
-            if (service_state != "running" or service_active_state != "active") and service_unit_state != "not-found":
-                self.result_list.append(f"WARNING - {service_desc} ({service_name}) is {service_state}.")
+            if service_name in self.options.ignore_services:
+                self.result_list.append(f"OK - {service_name_with_details}. State is ignored.")
+            elif service_unit_state == "not-found":
+                self.result_list.append(f"OK - {service_name_with_details}. Ignored as in state not-found.")
+            elif (service_state == "running" or service_active_state == "active"):
+                self.result_list.append(f"OK - {service_name_with_details}.")
             else:
-                if not any("WARNING" in x for x in self.result_list):
-                    self.result_list.append(f"OK - All services are running.")
-
-            if any("WARNING" in x for x in self.result_list):
-                self.result_list = [x for x in self.result_list if re.search("WARNING -", x)]
+                self.result_list.append(f"WARNING - {service_name_with_details}.")
 
         self.result_list = set(self.result_list)
-
-
 
     def check_storage(self, request_output, subcommand):
         

--- a/check_pve2.py
+++ b/check_pve2.py
@@ -122,7 +122,7 @@ class CheckPVE:
                                         help='Ignore disks in health check, --ignore-disk disk1 --ignore-disk disk2 ...etc', default=[])
 
         check_pve_opt.add_argument('--ignore-service', dest='ignore_services', action='append', metavar='SVCNAME',
-                                        help='Ignore services in services health check, --ignore-service corosync --ignore_service xyz ...etc', default=[])
+                                        help='Ignore services in services health check, --ignore-service corosync --ignore-service xyz ...etc', default=[])
 
         check_pve_opt.add_argument('--ignore-lxc-id', dest='ignore_lxc_ids', action='append', metavar='VMID', type=int,
                         help='Ignore LXC by VMID in lxc check, --ignore-lxc-id 101 --ignore-lxc-id 102 ...etc', default=[])
@@ -411,7 +411,7 @@ class CheckPVE:
                 self.result_list.append(f"OK - {service_name_with_details}. State is ignored.")
             elif service_unit_state == "not-found":
                 self.result_list.append(f"OK - {service_name_with_details}. Ignored as in state not-found.")
-            elif (service_state == "running" or service_active_state == "active"):
+            elif service_state == "running" and service_active_state == "active":
                 self.result_list.append(f"OK - {service_name_with_details}.")
             else:
                 self.result_list.append(f"WARNING - {service_name_with_details}.")

--- a/check_pve2.py
+++ b/check_pve2.py
@@ -92,6 +92,8 @@ class CheckPVE:
             {self.pluginname} --hostname pve.mydomain.com --api_user monitoring@pve --api_token A12fhaDFCjn92aKt=123f922a-e10b-12z7-e133-Aa3476b866ar --subcommand cpu --nodename pve1 --warning 65 --critical 85
             {self.pluginname} --hostname pve.mydomain.com --api_user monitoring@pve --api_token A12fhaDFCjn92aKt=123f922a-e10b-12z7-e133-Aa3476b866ar --subcommand cluster --nodename pve1
             {self.pluginname} --hostname pve.mydomain.com --api_user monitoring@pve --api_token A12fhaDFCjn92aKt=123f922a-e10b-12z7-e133-Aa3476b866ar --subcommand storage --nodename pve1 --warning 70 --critical 80 --ignore-disk vm-backup
+            {self.pluginname} --hostname pve.mydomain.com --api_user monitoring@pve --api_token A12fhaDFCjn92aKt=123f922a-e10b-12z7-e133-Aa3476b866ar --subcommand lxc --nodename pve1 --warning 80 --critical 90 --ignore-lxc-id 101 --ignore-lxc-id 108
+            {self.pluginname} --hostname pve.mydomain.com --api_user monitoring@pve --api_token A12fhaDFCjn92aKt=123f922a-e10b-12z7-e133-Aa3476b866ar --subcommand qemu --nodename pve1 --warning 80 --critical 90 --ignore-qemu-id 200
             with api password:
             {self.pluginname} --hostname pve.mydomain.com --api_user monitoring@pve --api_password mypassword --subcommand storage --nodename pve1 --ignore-disk disk1 --ignore-disk disk2 --warning 80 --critical 85"""))
 
@@ -112,8 +114,7 @@ class CheckPVE:
                                         choices=(
                                             'ceph', 'ceph_io', 'cluster', 'cpu', 'disks_health', 'lxc', 'memory', 'pveversion', 'qemu', 'services', 'storage', 'swap'),
                                         required=True,
-                                        help="Select subcommand to use. Some subcommands need warning and critical arguments. \
-                                            Disks, lxc and qemu subcommands need warning and critical thresholds.")
+                                        help="Select subcommand to use. cpu, memory, swap, storage, disks_health, lxc and qemu need warning and critical thresholds.")
         
         check_pve_opt.add_argument('--nodename', type=str, required=True, help="node name")
         
@@ -133,16 +134,16 @@ class CheckPVE:
                                         help='Check disks in health check by disk name, --disk-name disk1 --disk-name disk2 ...etc', default=[])
         
         check_pve_opt.add_argument('--ceph-io-warning', dest='ceph_io_warning', type=int,
-                                help='IO read/write warning threshold for cheph-io checking. Default: 10000 operations/sec', default=10000)
+                                help='IO read/write warning threshold for ceph-io checking. Default: 10000 operations/sec', default=10000)
         
         check_pve_opt.add_argument('--ceph-byte-warning', dest='ceph_byte_warning', type=int,
-                                help='Byte read/write warning threshold for cheph-io checking. Default: 200MB/sec', default=200)
+                                help='Byte read/write warning threshold for ceph-io checking. Default: 200MB/sec', default=200)
 
         check_pve_opt.add_argument('--warning', dest='threshold_warning', type=int,
-                                help='Warning threshold for check value. Mutiple thresholds with name:value,name:value')
+                                help='Warning threshold in percent for cpu, memory, swap, storage, disks_health, lxc and qemu checks')
         
         check_pve_opt.add_argument('--critical', dest='threshold_critical', type=int,
-                                help='Critical threshold for check value. Mutiple thresholds with name:value,name:value')
+                                help='Critical threshold in percent for cpu, memory, swap, storage, disks_health, lxc and qemu checks')
 
         self.options = parser.parse_args()
 

--- a/check_pve2.py
+++ b/check_pve2.py
@@ -4,7 +4,7 @@
 # COREX Proxmox VE check plugin for Icinga 2
 # Copyright (C) 2019-2024  Gabor Borsos <bg@corex.bg>
 # 
-# v1.25 built on 2024.06.03.
+# v2.0 built on 2026.05.23.
 # usage: check_pve2.py --help
 #
 # For bugs and feature requests mailto bg@corex.bg
@@ -27,6 +27,7 @@
 # changelog:
 # 2026.05.23. v2.0   - disk wearout is reversed to match proxmox UI and make more sense (0=no wearout, 100=full wearout)
 #                    - fix output and add verbosity for disks_health output (include wearout details when OK)
+#                    - add per-guest status checks for LXC and QEMU
 # 2024.06.03. v1.25  - PVE8 - Ignore the syslog service based on the deprecation in Debian 12.5
 # 2024.04.01. v1.24  - Add ceph-io subcommand
 # 2022.12.13. v1.23  - Add help
@@ -105,14 +106,14 @@ class CheckPVE:
                               help="Don't verify HTTPS certificate")
 
 
-        check_pve_opt = parser.add_argument_group('check arguments', 'ceph, ceph_io, cluster, cpu, disks_health, memory, pveversion, services, storage, swap')
+        check_pve_opt = parser.add_argument_group('check arguments', 'ceph, ceph_io, cluster, cpu, disks_health, lxc, memory, pveversion, qemu, services, storage, swap')
         
         check_pve_opt.add_argument("--subcommand",
                                         choices=(
-                                            'ceph', 'ceph_io', 'cluster', 'cpu', 'disks_health', 'memory', 'pveversion', 'services', 'storage', 'swap'),
+                                            'ceph', 'ceph_io', 'cluster', 'cpu', 'disks_health', 'lxc', 'memory', 'pveversion', 'qemu', 'services', 'storage', 'swap'),
                                         required=True,
                                         help="Select subcommand to use. Some subcommands need warning and critical arguments. \
-                                            Disk subcommand needs warning and critical to check wearout state.")
+                                            Disks, lxc and qemu subcommands need warning and critical thresholds.")
         
         check_pve_opt.add_argument('--nodename', type=str, required=True, help="node name")
         
@@ -121,6 +122,12 @@ class CheckPVE:
 
         check_pve_opt.add_argument('--ignore-service', dest='ignore_services', action='append', metavar='SVCNAME',
                                         help='Ignore services in services health check, --ignore-service corosync --ignore_service xyz ...etc', default=[])
+
+        check_pve_opt.add_argument('--ignore-lxc-id', dest='ignore_lxc_ids', action='append', metavar='VMID', type=int,
+                        help='Ignore LXC by VMID in lxc check, --ignore-lxc-id 101 --ignore-lxc-id 102 ...etc', default=[])
+
+        check_pve_opt.add_argument('--ignore-qemu-id', dest='ignore_qemu_ids', action='append', metavar='VMID', type=int,
+                        help='Ignore QEMU by VMID in qemu check, --ignore-qemu-id 201 --ignore-qemu-id 202 ...etc', default=[])
 
         check_pve_opt.add_argument('--disk-name', dest='include_disks', action='append', metavar='DISKNAME',
                                         help='Check disks in health check by disk name, --disk-name disk1 --disk-name disk2 ...etc', default=[])
@@ -139,8 +146,9 @@ class CheckPVE:
 
         self.options = parser.parse_args()
 
-        if (self.options.subcommand == "cpu" or self.options.subcommand == "disks_health" or self.options.subcommand == "memory" or \
-            self.options.subcommand == "storage" or self.options.subcommand == "swap") and \
+        if (self.options.subcommand == "cpu" or self.options.subcommand == "disks_health" or self.options.subcommand == "lxc" or \
+            self.options.subcommand == "memory" or self.options.subcommand == "qemu" or self.options.subcommand == "storage" or \
+            self.options.subcommand == "swap") and \
             (self.options.threshold_warning is None or self.options.threshold_critical is None):
             
             parser.error(f"--warning and --critical arguments are required for '{self.options.subcommand}' subcommand!")
@@ -173,6 +181,10 @@ class CheckPVE:
             return self.API_URL.format(hostname=self.options.api_host, port=self.options.api_port, command=f"nodes/{self.options.nodename}/storage")
         elif apiurl == "services":
             return self.API_URL.format(hostname=self.options.api_host, port=self.options.api_port, command=f"nodes/{self.options.nodename}/services")
+        elif apiurl == "lxc":
+            return self.API_URL.format(hostname=self.options.api_host, port=self.options.api_port, command=f"nodes/{self.options.nodename}/lxc")
+        elif apiurl == "qemu":
+            return self.API_URL.format(hostname=self.options.api_host, port=self.options.api_port, command=f"nodes/{self.options.nodename}/qemu")
         else:
             return self.API_URL.format(hostname=self.options.api_host, port=self.options.api_port, command=apiurl)
 
@@ -241,7 +253,9 @@ class CheckPVE:
 
 
     def check_thresholds_scale(self):
-        if (self.options.subcommand == "cpu" or self.options.subcommand == "memory" or self.options.subcommand == "storage" or self.options.subcommand == "swap" or self.options.subcommand == "disks_health"):
+        if (self.options.subcommand == "cpu" or self.options.subcommand == "disks_health" or self.options.subcommand == "lxc" or \
+            self.options.subcommand == "memory" or self.options.subcommand == "qemu" or self.options.subcommand == "storage" or \
+            self.options.subcommand == "swap"):
             return(self.options.threshold_warning < self.options.threshold_critical)
 
 
@@ -335,15 +349,18 @@ class CheckPVE:
             disk_health = disk["health"]
             disk_wearout = 100 - disk["wearout"] # in API we got 0 for maximum wearout and 100 for none; reverse it to match proxmox UI and to make more sense
             disk_name_with_details = f"{disk_model} ({disk_type}, SN: {disk_serial}) on {disk_devpath}"
+            disk_perf_name = re.sub(r"[^A-Za-z0-9_]+", "_", f"disk_{disk_devpath}").strip("_").lower()
+            wearout_perf_value = disk_wearout if isinstance(disk_wearout, (int, float)) else "U"
+            perfdata = f"|'{disk_perf_name}_wearout'={wearout_perf_value}%;{self.options.threshold_warning};{self.options.threshold_critical};0;100"
 
             if disk_health != "OK" and disk_health != "PASSED" and disk_health != "UNKNOWN":
-                self.result_list.append(f"CRITICAL - {disk_name_with_details} has failed: {disk_health}")
+                self.result_list.append(f"CRITICAL - {disk_name_with_details} has failed: {disk_health}. {perfdata}")
             elif isinstance(disk_wearout, int) and disk_wearout >= self.options.threshold_critical:
-                self.result_list.append(f"CRITICAL - {disk_name_with_details} has high wearout {disk_wearout}%")
+                self.result_list.append(f"CRITICAL - {disk_name_with_details} has high wearout {disk_wearout}%. {perfdata}")
             elif isinstance(disk_wearout, int) and disk_wearout >= self.options.threshold_warning:
-                self.result_list.append(f"WARNING - {disk_name_with_details} has high wearout {disk_wearout}%")
+                self.result_list.append(f"WARNING - {disk_name_with_details} has high wearout {disk_wearout}%. {perfdata}")
             else:
-                self.result_list.append(f"OK - {disk_name_with_details} has low wearout {disk_wearout}%")
+                self.result_list.append(f"OK - {disk_name_with_details} has low wearout {disk_wearout}%. {perfdata}")
 	
         self.result_list = set(self.result_list)
 
@@ -399,6 +416,73 @@ class CheckPVE:
                 self.result_list.append(f"WARNING - {service_name_with_details}.")
 
         self.result_list = set(self.result_list)
+
+
+    def check_lxc(self, request_output, subcommand):
+        self.check_guests(request_output, "lxc", self.options.ignore_lxc_ids)
+
+
+    def check_qemu(self, request_output, subcommand):
+        self.check_guests(request_output, "qemu", self.options.ignore_qemu_ids)
+
+
+    def check_guests(self, request_output, guest_type, ignore_vmid_list):
+        for guest in request_output:
+            vmid = guest.get("vmid", "unknown")
+            vmid_int = None
+            try:
+                vmid_int = int(vmid)
+            except (TypeError, ValueError):
+                vmid_int = None
+
+            guest_name = guest.get("name", f"{guest_type}-{vmid}")
+            guest_status = guest.get("status", guest.get("qmpstatus", "unknown"))
+            guest_cpus = guest.get("cpus", 0)
+            guest_uptime = guest.get("uptime", 0)
+
+            if vmid_int is not None and vmid_int in ignore_vmid_list:
+                self.result_list.append(f"OK - {guest_type.upper()} {guest_name} (vmid: {vmid}) is ignored.")
+                continue
+
+            cpu_raw = guest.get("cpu", 0)
+            cpu_percent = round((cpu_raw * 100), 2)
+
+            mem_used = guest.get("mem", 0)
+            mem_total = guest.get("maxmem", 0)
+            swap_used = guest.get("swap", 0)
+            swap_total = guest.get("maxswap", 0)
+            disk_used = guest.get("disk", 0)
+            disk_total = guest.get("maxdisk", 0)
+
+            mem_percent = round((mem_used / mem_total) * 100, 2) if mem_total else 0
+            swap_percent = round((swap_used / swap_total) * 100, 2) if swap_total else 0
+            disk_percent = round((disk_used / disk_total) * 100, 2) if disk_total else 0
+
+            guest_label = f"{guest_type}_{vmid}"
+            perfdata = f"|'{guest_label}_cpu'={cpu_percent}%;0;100;0;100 " \
+                       f"'{guest_label}_mem'={mem_percent}%;{self.options.threshold_warning};{self.options.threshold_critical};0;100 " \
+                       f"'{guest_label}_swap'={swap_percent}%;{self.options.threshold_warning};{self.options.threshold_critical};0;100 " \
+                       f"'{guest_label}_disk'={disk_percent}%;{self.options.threshold_warning};{self.options.threshold_critical};0;100"
+
+            base_message = f"{guest_type.upper()} {guest_name} (vmid: {vmid}) is {guest_status} " \
+                           f"(cpu: {cpu_percent}%, mem: {mem_percent}%, swap: {swap_percent}%, disk: {disk_percent}%, cpus: {guest_cpus}, uptime: {guest_uptime}s)"
+
+            threshold_values = {
+                "memory": mem_percent,
+                "swap": swap_percent,
+                "disk": disk_percent,
+            }
+            critical_metrics = [name for name, value in threshold_values.items() if value >= self.options.threshold_critical]
+            warning_metrics = [name for name, value in threshold_values.items() if self.options.threshold_warning <= value < self.options.threshold_critical]
+
+            if guest_status != "running":
+                self.result_list.append(f"CRITICAL - {base_message}. {perfdata}")
+            elif len(critical_metrics) > 0:
+                self.result_list.append(f"CRITICAL - {base_message}; exceeded critical threshold on: {', '.join(critical_metrics)}. {perfdata}")
+            elif len(warning_metrics) > 0:
+                self.result_list.append(f"WARNING - {base_message}; exceeded warning threshold on: {', '.join(warning_metrics)}. {perfdata}")
+            else:
+                self.result_list.append(f"OK - {base_message}. {perfdata}")
 
     def check_storage(self, request_output, subcommand):
         

--- a/check_pve2.py
+++ b/check_pve2.py
@@ -38,7 +38,7 @@
 # 2022.10.23. v1.0  - First release
 # ---------------------------------------------------------------
 
-import re, sys
+import re, sys, math
 
 try:
     from enum import Enum
@@ -348,17 +348,32 @@ class CheckPVE:
             disk_type = disk["type"]
             disk_devpath = disk["devpath"]
             disk_health = disk["health"]
-            disk_wearout = 100 - disk["wearout"] # in API we got 0 for maximum wearout and 100 for none; reverse it to match proxmox UI and to make more sense
+            disk_wearout_raw = disk.get("wearout")
+            disk_wearout_value = None
+
+            try:
+                parsed_wearout = float(disk_wearout_raw)
+                if math.isfinite(parsed_wearout):
+                    disk_wearout_value = parsed_wearout
+            except (TypeError, ValueError):
+                pass
+
+            if disk_wearout_value is None:
+                # disk wearout value if not available - set it to 0 to avoid false warning/critical alerts
+                disk_wearout = 0
+            else:
+                # in API we got 0 for maximum wearout and 100 for none; reverse it to match proxmox UI and to make more sense
+                disk_wearout = round(100 - disk_wearout_value, 2)
+
             disk_name_with_details = f"{disk_model} ({disk_type}, SN: {disk_serial}) on {disk_devpath}"
             disk_perf_name = re.sub(r"[^A-Za-z0-9_]+", "_", f"disk_{disk_devpath}").strip("_").lower()
-            wearout_perf_value = disk_wearout if isinstance(disk_wearout, (int, float)) else "U"
-            perfdata = f"|'{disk_perf_name}_wearout'={wearout_perf_value}%;{self.options.threshold_warning};{self.options.threshold_critical};0;100"
+            perfdata = f"|'{disk_perf_name}_wearout'={disk_wearout}%;{self.options.threshold_warning};{self.options.threshold_critical};0;100"
 
             if disk_health != "OK" and disk_health != "PASSED" and disk_health != "UNKNOWN":
                 self.result_list.append(f"CRITICAL - {disk_name_with_details} has failed: {disk_health}. {perfdata}")
-            elif isinstance(disk_wearout, int) and disk_wearout >= self.options.threshold_critical:
+            elif isinstance(disk_wearout, (int, float)) and disk_wearout >= self.options.threshold_critical:
                 self.result_list.append(f"CRITICAL - {disk_name_with_details} has high wearout {disk_wearout}%. {perfdata}")
-            elif isinstance(disk_wearout, int) and disk_wearout >= self.options.threshold_warning:
+            elif isinstance(disk_wearout, (int, float)) and disk_wearout >= self.options.threshold_warning:
                 self.result_list.append(f"WARNING - {disk_name_with_details} has high wearout {disk_wearout}%. {perfdata}")
             else:
                 self.result_list.append(f"OK - {disk_name_with_details} has low wearout {disk_wearout}%. {perfdata}")

--- a/check_pve2.py
+++ b/check_pve2.py
@@ -28,6 +28,7 @@
 # 2026.05.23. v2.0   - disk wearout is reversed to match proxmox UI and make more sense (0=no wearout, 100=full wearout)
 #                    - fix output and add verbosity for disks_health output (include wearout details when OK)
 #                    - add per-guest status checks for LXC and QEMU
+#                    - add backup check for latest vzdump task status and backup age thresholds
 # 2024.06.03. v1.25  - PVE8 - Ignore the syslog service based on the deprecation in Debian 12.5
 # 2024.04.01. v1.24  - Add ceph-io subcommand
 # 2022.12.13. v1.23  - Add help
@@ -94,6 +95,7 @@ class CheckPVE:
             {self.pluginname} --hostname pve.mydomain.com --api_user monitoring@pve --api_token A12fhaDFCjn92aKt=123f922a-e10b-12z7-e133-Aa3476b866ar --subcommand storage --nodename pve1 --warning 70 --critical 80 --ignore-disk vm-backup
             {self.pluginname} --hostname pve.mydomain.com --api_user monitoring@pve --api_token A12fhaDFCjn92aKt=123f922a-e10b-12z7-e133-Aa3476b866ar --subcommand lxc --nodename pve1 --warning 80 --critical 90 --ignore-lxc-id 101 --ignore-lxc-id 108
             {self.pluginname} --hostname pve.mydomain.com --api_user monitoring@pve --api_token A12fhaDFCjn92aKt=123f922a-e10b-12z7-e133-Aa3476b866ar --subcommand qemu --nodename pve1 --warning 80 --critical 90 --ignore-qemu-id 200
+            {self.pluginname} --hostname pve.mydomain.com --api_user monitoring@pve --api_token A12fhaDFCjn92aKt=123f922a-e10b-12z7-e133-Aa3476b866ar --subcommand backup --nodename pve1 --warning 7 --critical 14
             with api password:
             {self.pluginname} --hostname pve.mydomain.com --api_user monitoring@pve --api_password mypassword --subcommand storage --nodename pve1 --ignore-disk disk1 --ignore-disk disk2 --warning 80 --critical 85"""))
 
@@ -108,13 +110,13 @@ class CheckPVE:
                               help="Don't verify HTTPS certificate")
 
 
-        check_pve_opt = parser.add_argument_group('check arguments', 'ceph, ceph_io, cluster, cpu, disks_health, lxc, memory, pveversion, qemu, services, storage, swap')
+        check_pve_opt = parser.add_argument_group('check arguments', 'backup, ceph, ceph_io, cluster, cpu, disks_health, lxc, memory, pveversion, qemu, services, storage, swap')
         
         check_pve_opt.add_argument("--subcommand",
                                         choices=(
-                                            'ceph', 'ceph_io', 'cluster', 'cpu', 'disks_health', 'lxc', 'memory', 'pveversion', 'qemu', 'services', 'storage', 'swap'),
+                                            'backup', 'ceph', 'ceph_io', 'cluster', 'cpu', 'disks_health', 'lxc', 'memory', 'pveversion', 'qemu', 'services', 'storage', 'swap'),
                                         required=True,
-                                        help="Select subcommand to use. cpu, memory, swap, storage, disks_health, lxc and qemu need warning and critical thresholds.")
+                                        help="Select subcommand to use. cpu, memory, swap, storage, disks_health, lxc, qemu and backup need warning and critical thresholds.")
         
         check_pve_opt.add_argument('--nodename', type=str, required=True, help="node name")
         
@@ -140,16 +142,16 @@ class CheckPVE:
                                 help='Byte read/write warning threshold for ceph-io checking. Default: 200MB/sec', default=200)
 
         check_pve_opt.add_argument('--warning', dest='threshold_warning', type=int,
-                                help='Warning threshold in percent for cpu, memory, swap, storage, disks_health, lxc and qemu checks')
+                                help='Warning threshold for cpu, memory, swap, storage, disks_health, lxc, qemu and backup checks (percent or days)')
         
         check_pve_opt.add_argument('--critical', dest='threshold_critical', type=int,
-                                help='Critical threshold in percent for cpu, memory, swap, storage, disks_health, lxc and qemu checks')
+                                help='Critical threshold for cpu, memory, swap, storage, disks_health, lxc, qemu and backup checks (percent or days)')
 
         self.options = parser.parse_args()
 
-        if (self.options.subcommand == "cpu" or self.options.subcommand == "disks_health" or self.options.subcommand == "lxc" or \
-            self.options.subcommand == "memory" or self.options.subcommand == "qemu" or self.options.subcommand == "storage" or \
-            self.options.subcommand == "swap") and \
+        if (self.options.subcommand == "backup" or self.options.subcommand == "cpu" or self.options.subcommand == "disks_health" or \
+            self.options.subcommand == "lxc" or self.options.subcommand == "memory" or self.options.subcommand == "qemu" or \
+            self.options.subcommand == "storage" or self.options.subcommand == "swap") and \
             (self.options.threshold_warning is None or self.options.threshold_critical is None):
             
             parser.error(f"--warning and --critical arguments are required for '{self.options.subcommand}' subcommand!")
@@ -172,6 +174,8 @@ class CheckPVE:
             return self.API_URL.format(hostname=self.options.api_host, port=self.options.api_port, command=f"nodes/{self.options.nodename}/status")
         elif apiurl == "disks_health":
             return self.API_URL.format(hostname=self.options.api_host, port=self.options.api_port, command=f"nodes/{self.options.nodename}/disks/list")
+        elif apiurl == "backup":
+            return self.API_URL.format(hostname=self.options.api_host, port=self.options.api_port, command=f"nodes/{self.options.nodename}/tasks")
         elif apiurl == "ceph":
             return self.API_URL.format(hostname=self.options.api_host, port=self.options.api_port, command="cluster/ceph/status")
         elif apiurl == "ceph_io":
@@ -254,9 +258,9 @@ class CheckPVE:
 
 
     def check_thresholds_scale(self):
-        if (self.options.subcommand == "cpu" or self.options.subcommand == "disks_health" or self.options.subcommand == "lxc" or \
-            self.options.subcommand == "memory" or self.options.subcommand == "qemu" or self.options.subcommand == "storage" or \
-            self.options.subcommand == "swap"):
+        if (self.options.subcommand == "backup" or self.options.subcommand == "cpu" or self.options.subcommand == "disks_health" or \
+            self.options.subcommand == "lxc" or self.options.subcommand == "memory" or self.options.subcommand == "qemu" or \
+            self.options.subcommand == "storage" or self.options.subcommand == "swap"):
             return(self.options.threshold_warning < self.options.threshold_critical)
 
 
@@ -285,7 +289,6 @@ class CheckPVE:
         else:
             self.result_list.append(f"OK - {message}")
 
-    
         message = f"CEPH IO byte usage is {read_bytes_sec} MB read / {write_bytes_sec} MB write per seconds.\
         |'ceph byte read per sec'={read_bytes_sec};{ceph_byte_warning};;0; 'ceph byte write per sec'={write_bytes_sec};{ceph_byte_warning};;0;"
         
@@ -293,6 +296,62 @@ class CheckPVE:
             self.result_list.append(f"WARNING - {message}")
         else:
             self.result_list.append(f"OK - {message}")
+
+
+    def check_backup(self, request_output, subcommand):
+        backup_tasks = [task for task in request_output if task.get("type") == "vzdump"]
+
+        if len(backup_tasks) == 0:
+            self.output(CheckState.WARNING, "No backup tasks found for this node.")
+
+        def task_started_at(task):
+            try:
+                return int(task.get("starttime", 0))
+            except (TypeError, ValueError):
+                return 0
+
+        latest_task = max(backup_tasks, key=task_started_at)
+        successful_tasks = [task for task in backup_tasks if str(task.get("status", "")).upper() == "OK"]
+        latest_successful_task = max(successful_tasks, key=task_started_at) if len(successful_tasks) > 0 else None
+
+        latest_task_status = str(latest_task.get("status", "unknown")).upper()
+        latest_task_text = latest_task.get("id", latest_task.get("upid", "unknown backup task"))
+        message_parts = [f"Latest backup task {latest_task_text} ended with status {latest_task_status}"]
+
+        if latest_task_status != "OK":
+            failure_state = CheckState.WARNING
+            message_parts.append("last backup failed")
+        else:
+            failure_state = CheckState.OK
+            message_parts.append("last backup succeeded")
+
+        if latest_successful_task is None:
+            age_state = CheckState.WARNING
+            age_days = None
+            message_parts.append("no successful backup was found")
+        else:
+            try:
+                latest_successful_start = int(latest_successful_task.get("starttime", 0))
+            except (TypeError, ValueError):
+                latest_successful_start = 0
+
+            age_days = round((datetime.now() - datetime.fromtimestamp(latest_successful_start)).total_seconds() / 86400, 2)
+            if age_days >= self.options.threshold_critical:
+                age_state = CheckState.CRITICAL
+            elif age_days >= self.options.threshold_warning:
+                age_state = CheckState.WARNING
+            else:
+                age_state = CheckState.OK
+
+            message_parts.append(f"last successful backup is {age_days} days old")
+
+        final_state = failure_state
+        if age_state.value > final_state.value:
+            final_state = age_state
+
+        perfdata_age = age_days if age_days is not None else "U"
+        perfdata = f"|'backup_age_days'={perfdata_age};{self.options.threshold_warning};{self.options.threshold_critical};0;"
+        self.result_list.append(f"{final_state.name} - {'; '.join(message_parts)}. {perfdata}")
         
 
 

--- a/readme.md
+++ b/readme.md
@@ -65,10 +65,11 @@ OK - QEMU vm-router (vmid: 201) is running (cpu: 5.49%, mem: 41.63%, swap: 12.4%
 
 ### Changelog
  
-- 2026.05.23. v2.0   - disk wearout is reversed to match proxmox UI and make more sense (0=no wearout, 100=full wearout)
-					- add per-guest status checks for LXC and QEMU
-					- add warning/critical threshold evaluation on LXC/QEMU memory, swap and disk
-					- add ignore options by guest VMID for LXC and QEMU checks
+- 2026.05.23. v2.0
+  - disk wearout is reversed to match proxmox UI and make more sense (0=no wearout, 100=full wearout)
+  - add per-guest status checks for LXC and QEMU
+  - add warning/critical threshold evaluation on LXC/QEMU memory, swap and disk
+  - add ignore options by guest VMID for LXC and QEMU checks
 - 2024.06.03. v1.25  - PVE8 - Ignore the syslog service based on the deprecation in Debian 12.5
 - 2024.04.01. v1.24  - Add ceph-io subcommand
 - 2022.12.13. v1.23  - Add help

--- a/readme.md
+++ b/readme.md
@@ -41,17 +41,22 @@ OK - corexcluster cluster is working well.
 </code></pre>
 
 <pre><code>
-# cd /usr/lib/nagios/plugins
 # ./check_pve2.py --hostname pve.mydomain.com --api_user monitoring@pve --api_token A12fhaDFCjn92aKt=123f922a-e10b-12z7-e133-Aa3476b866ar --subcommand lxc --nodename pve1 --warning 80 --critical 90 --ignore-lxc-id 101 --ignore-lxc-id 108
 OK - LXC prom (vmid: 101) is ignored.
 WARNING - LXC webserver (vmid: 103) is running (cpu: 3.1%, mem: 84.22%, swap: 0.0%, disk: 61.17%, cpus: 2, uptime: 2526251s); exceeded warning threshold on: memory. |'lxc_103_cpu'=3.1%;0;100;0;100 'lxc_103_mem'=84.22%;80;90;0;100 'lxc_103_swap'=0.0%;80;90;0;100 'lxc_103_disk'=61.17%;80;90;0;100
 
 </code></pre>
-
 <pre><code>
 # cd /usr/lib/nagios/plugins
 # ./check_pve2.py --hostname pve.mydomain.com --api_user monitoring@pve --api_token A12fhaDFCjn92aKt=123f922a-e10b-12z7-e133-Aa3476b866ar --subcommand qemu --nodename pve1 --warning 80 --critical 90 --ignore-qemu-id 200
 OK - QEMU vm-router (vmid: 201) is running (cpu: 5.49%, mem: 41.63%, swap: 12.4%, disk: 54.09%, cpus: 2, uptime: 864000s). |'qemu_201_cpu'=5.49%;0;100;0;100 'qemu_201_mem'=41.63%;80;90;0;100 'qemu_201_swap'=12.4%;80;90;0;100 'qemu_201_disk'=54.09%;80;90;0;100
+
+</code></pre>
+
+<pre><code>
+# cd /usr/lib/nagios/plugins
+# ./check_pve2.py --hostname pve.mydomain.com --api_user monitoring@pve --api_token A12fhaDFCjn92aKt=123f922a-e10b-12z7-e133-Aa3476b866ar --subcommand backup --nodename pve1 --warning 7 --critical 14
+OK - Latest backup task vzdump:... ended with status OK; last backup succeeded; last successful backup is 2.13 days old. |'backup_age_days'=2.13;7;14;0;
 
 </code></pre>
 
@@ -70,6 +75,7 @@ OK - QEMU vm-router (vmid: 201) is running (cpu: 5.49%, mem: 41.63%, swap: 12.4%
   - add per-guest status checks for LXC and QEMU
   - add warning/critical threshold evaluation on LXC/QEMU memory, swap and disk
   - add ignore options by guest VMID for LXC and QEMU checks
+  - add backup check for latest vzdump task status and backup age thresholds
 - 2024.06.03. v1.25  - PVE8 - Ignore the syslog service based on the deprecation in Debian 12.5
 - 2024.04.01. v1.24  - Add ceph-io subcommand
 - 2022.12.13. v1.23  - Add help

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ COREX PROXMOX VE check plugin for Icinga 2
  - checks PROXMOX VE host over API
  - authentication with api key and password
  - prints performance data for Icinga 2 Graphite Module ( and other solutions like Graphite )
- - available subcommands: ceph, cluster, cpu, disks_health, memory, pveversion, services, storage, swap
+ - available subcommands: ceph, ceph_io, cluster, cpu, disks_health, lxc, memory, pveversion, qemu, services, storage, swap
  - warning/critical thresholds for each separate subcommands
  - for more details run check_pve2.py --help
 
@@ -41,7 +41,7 @@ OK - corexcluster cluster is working well.
 
 ### Version
 
- - 1.25
+ - 2.0
 
 ### ToDo
 
@@ -49,6 +49,8 @@ OK - corexcluster cluster is working well.
 
 ### Changelog
  
+- 2026.05.23. v2.0   - disk wearout is reversed to match proxmox UI and make more sense (0=no wearout, 100=full wearout)
+					- add per-guest status checks for LXC and QEMU
 - 2024.06.03. v1.25  - PVE8 - Ignore the syslog service based on the deprecation in Debian 12.5
 - 2024.04.01. v1.24  - Add ceph-io subcommand
 - 2022.12.13. v1.23  - Add help

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,8 @@ COREX PROXMOX VE check plugin for Icinga 2
  - authentication with api key and password
  - prints performance data for Icinga 2 Graphite Module ( and other solutions like Graphite )
  - available subcommands: ceph, ceph_io, cluster, cpu, disks_health, lxc, memory, pveversion, qemu, services, storage, swap
- - warning/critical thresholds for each separate subcommands
+ - warning/critical thresholds for cpu, memory, swap, storage, disks_health, lxc and qemu
+ - ignore selected guests by VMID in lxc/qemu checks (--ignore-lxc-id, --ignore-qemu-id)
  - for more details run check_pve2.py --help
 
 ### Usage
@@ -34,8 +35,23 @@ OK - ceph_ssd disk usage (type: rbd) is 62.29 % (5.88 TB / 9.44 TB).            
 
 <pre><code>
 # cd /usr/lib/nagios/plugins
-# ./check_pve2.py --hostname pve.mydomain.com --api_user monitoring@pve --api_password nagios --subcommand cluster
+# ./check_pve2.py --hostname pve.mydomain.com --api_user monitoring@pve --api_password nagios --subcommand cluster --nodename pve1
 OK - corexcluster cluster is working well.
+
+</code></pre>
+
+<pre><code>
+# cd /usr/lib/nagios/plugins
+# ./check_pve2.py --hostname pve.mydomain.com --api_user monitoring@pve --api_token A12fhaDFCjn92aKt=123f922a-e10b-12z7-e133-Aa3476b866ar --subcommand lxc --nodename pve1 --warning 80 --critical 90 --ignore-lxc-id 101 --ignore-lxc-id 108
+OK - LXC prom (vmid: 101) is ignored.
+WARNING - LXC webserver (vmid: 103) is running (cpu: 3.1%, mem: 84.22%, swap: 0.0%, disk: 61.17%, cpus: 2, uptime: 2526251s); exceeded warning threshold on: memory. |'lxc_103_cpu'=3.1%;0;100;0;100 'lxc_103_mem'=84.22%;80;90;0;100 'lxc_103_swap'=0.0%;80;90;0;100 'lxc_103_disk'=61.17%;80;90;0;100
+
+</code></pre>
+
+<pre><code>
+# cd /usr/lib/nagios/plugins
+# ./check_pve2.py --hostname pve.mydomain.com --api_user monitoring@pve --api_token A12fhaDFCjn92aKt=123f922a-e10b-12z7-e133-Aa3476b866ar --subcommand qemu --nodename pve1 --warning 80 --critical 90 --ignore-qemu-id 200
+OK - QEMU vm-router (vmid: 201) is running (cpu: 5.49%, mem: 41.63%, swap: 12.4%, disk: 54.09%, cpus: 2, uptime: 864000s). |'qemu_201_cpu'=5.49%;0;100;0;100 'qemu_201_mem'=41.63%;80;90;0;100 'qemu_201_swap'=12.4%;80;90;0;100 'qemu_201_disk'=54.09%;80;90;0;100
 
 </code></pre>
 
@@ -51,6 +67,8 @@ OK - corexcluster cluster is working well.
  
 - 2026.05.23. v2.0   - disk wearout is reversed to match proxmox UI and make more sense (0=no wearout, 100=full wearout)
 					- add per-guest status checks for LXC and QEMU
+					- add warning/critical threshold evaluation on LXC/QEMU memory, swap and disk
+					- add ignore options by guest VMID for LXC and QEMU checks
 - 2024.06.03. v1.25  - PVE8 - Ignore the syslog service based on the deprecation in Debian 12.5
 - 2024.04.01. v1.24  - Add ceph-io subcommand
 - 2022.12.13. v1.23  - Add help


### PR DESCRIPTION
Introduce v2.0

- disk wearout is reversed to match proxmox UI and make more sense (0=no wearout, 100=full wearout) - this is a reason to bumb up major version
- fix output and add verbosity for disks_health output (include wearout details when OK)
- add per-guest status checks for LXC and QEMU
- add backup check for latest vzdump task status and backup age thresholds