### PR TITLE
bugfix to avoid undefined ceph io readings

### DIFF
--- a/check_pve2.py
+++ b/check_pve2.py
@@ -25,6 +25,7 @@
 # ---------------------------------------------------------------
 #
 # changelog:
+# 2024.06.03. v1.26  - Bugfix, catch for when ceph io doesn't supply readings
 # 2024.06.03. v1.25  - PVE8 - Ignore the syslog service based on the deprecation in Debian 12.5
 # 2024.04.01. v1.24  - Add ceph-io subcommand
 # 2022.12.13. v1.23  - Add help
@@ -256,10 +257,12 @@ class CheckPVE:
 
 
     def check_ceph_io(self, perfdata, subcommand):
-        read_bytes_sec = round(int((perfdata["pgmap"]["read_bytes_sec"]))/1048576, 2)
-        write_bytes_sec = round(int((perfdata["pgmap"]["write_bytes_sec"]))/1048576, 2)
-        read_op_per_sec = int((perfdata["pgmap"]["read_op_per_sec"]))
-        write_op_per_sec = int((perfdata["pgmap"]["write_op_per_sec"]))
+        pgmap = perfdata["pgmap"]
+        # Set values to zero if the readings are undefined
+        read_bytes_sec = round(int(pgmap.get("read_bytes_sec", 0))/1048576, 2)
+        write_bytes_sec = round(int(pgmap.get("write_bytes_sec", 0))/1048576, 2)
+        read_op_per_sec = int(pgmap.get("read_op_per_sec", 0))
+        write_op_per_sec = int(pgmap.get("write_op_per_sec", 0))
         ceph_io_warning = self.options.ceph_io_warning
         ceph_byte_warning = self.options.ceph_byte_warning
 


### PR DESCRIPTION
When a proxmox node is idle (no workloads), sometimes ceph doesn't define a value for read_bytes_sec or other variables.
In such situations, this error occurs:
```
check_pve2.py --hostname $1 --nodename $2 --api_user $3 pve --api_token $4 --subcommand ceph_io
Traceback (most recent call last):
  File "/usr/local/plugins/check_pve2.py", line 525, in <module>
    check_pve.main()
  File "/usr/local/plugins/check_pve2.py", line 154, in main
    eval(f"self.check_{self.options.subcommand}" + "(request_output, self.options.subcommand)")
  File "<string>", line 1, in <module>
  File "/usr/local/plugins/check_pve2.py", line 259, in check_ceph_io
    read_bytes_sec = round(int((perfdata["pgmap"]["read_bytes_sec"]))/1048576, 2)
KeyError: 'read_bytes_sec'
```
Upon applying the fix, the error no longer appears. Have also tested with non-idle nodes, on proxmox 9.
```
OK - CEPH IO operation usage is 0 ops read / 0 ops write per seconds.        |'ceph io read per sec'=0;10000;;0; 'ceph io write per sec'=0;10000;;0;
OK - CEPH IO byte usage is 0.0 MB read / 0.0 MB write per seconds.        |'ceph byte read per sec'=0.0;200;;0; 'ceph byte write per sec'=0.0;200;;0;
```